### PR TITLE
adjust_config (existing script), entrypoint_observer (new script)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,24 @@
 # rosetta-docker-scripts
-Scripts referenced by Rosetta's Docker setup.
+
+Scripts referenced by [Rosetta's Docker setup](https://github.com/ElrondNetwork/rosetta-docker). **Not usable in other contexts.**
+
+These scripts are kept separately (in this repository) so that we can easily use versioned references towards them, and also to satisfy Rosetta's [build anywhere](https://www.rosetta-api.org/docs/node_deployment.html#build-anywhere) requirement.
+
+## `adjust_config.py`
+
+This script is used to tailor the default Observer configuration. More precisely, it alters the files `config.toml` and `prefs.toml` accordingly and adjusts settings related to `DbLookupExtensions`, `Antiflood` etc.
+
+## `entrypoint_observer.sh`
+
+This script should be used as the _entrypoint_ of the Observer image.
+
+Invocation example:
+
+```
+/elrond/entrypoint_observer.sh network=devnet ${NODE_CLI_ARGUMENTS}
+```
+
+Above, note the marker `network=devnet`. This marker selects the appropriate node configuration. For mainnet, `network=mainnet` should be used.
+
+## Notable references
+ - [Docker: How to execute a shell command before the ENTRYPOINT](https://stackoverflow.com/a/41518225)

--- a/README.md
+++ b/README.md
@@ -8,17 +8,9 @@ These scripts are kept separately (in this repository) so that we can easily use
 
 This script is used to tailor the default Observer configuration. More precisely, it alters the files `config.toml` and `prefs.toml` accordingly and adjusts settings related to `DbLookupExtensions`, `Antiflood` etc.
 
-## `entrypoint_observer.sh`
+## `entrypoint.sh`
 
-This script should be used as the _entrypoint_ of the Observer image.
-
-Invocation example:
-
-```
-/elrond/entrypoint_observer.sh network=devnet ${NODE_CLI_ARGUMENTS}
-```
-
-Above, note the marker `network=devnet`. This marker selects the appropriate node configuration. For mainnet, `network=mainnet` should be used.
+This script should be used as the _entrypoint_ of Rosetta's [Dockerfile](https://github.com/ElrondNetwork/rosetta-docker/blob/main/Dockerfile). It starts the requested program (`node` or `rosetta`), with the provided arguments, and with the appropriate configuration.
 
 ## Notable references
  - [Docker: How to execute a shell command before the ENTRYPOINT](https://stackoverflow.com/a/41518225)

--- a/adjust_config.py
+++ b/adjust_config.py
@@ -1,0 +1,45 @@
+
+import sys
+from argparse import ArgumentParser
+from typing import List
+
+import toml
+
+"""
+python3 ./docker/adjust_config.py --mode=main --file=/go/elrond-config-devnet/config.toml
+python3 ./docker/adjust_config.py --mode=prefs --file=/go/elrond-config-devnet/prefs.toml
+"""
+
+MODE_MAIN = "main"
+MODE_PREFS = "prefs"
+MODES = [MODE_MAIN, MODE_PREFS]
+
+
+def main(cli_args: List[str]):
+    parser = ArgumentParser()
+    parser.add_argument("--mode", choices=MODES, required=True)
+    parser.add_argument("--file", required=True)
+
+    parsed_args = parser.parse_args(cli_args)
+    mode = parsed_args.mode
+    file = parsed_args.file
+
+    data = toml.load(file)
+
+    if mode == MODE_MAIN:
+        data["GeneralSettings"]["StartInEpochEnabled"] = False
+        data["DbLookupExtensions"]["Enabled"] = True
+        data["Antiflood"]["WebServer"]["SimultaneousRequests"] = 512
+    elif mode == MODE_PREFS:
+        data["Preferences"]["FullArchive"] = True
+    else:
+        raise Exception(f"Unknown mode: {mode}")
+
+    with open(file, "w") as f:
+        toml.dump(data, f)
+
+    print(f"Configuration adjusted: mode = {mode}, file = {file}")
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/adjust_config.py
+++ b/adjust_config.py
@@ -1,4 +1,3 @@
-
 import sys
 from argparse import ArgumentParser
 from typing import List

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,20 +1,38 @@
 #!/bin/bash
 
+NETWORK=""
+PROGRAM=""
+ARGS=""
+
 # Decide network
 
-NETWORK=$1
 if [[ $@ == *"network=mainnet"* ]]; then
     NETWORK=mainnet
-    NODE_ARGS="${@//network=mainnet/}"
+    ARGS="${@//network=mainnet/}"
 elif [[ $@ == *"network=devnet"* ]]; then
     NETWORK=devnet
-    NODE_ARGS="${@//network=devnet/}"
+    ARGS="${@//network=devnet/}"
 else
     echo "Error: unknown network switch." 1>&2
     exit 1
 fi
 
 echo "Network: ${NETWORK}"
+
+# Decide program to run
+
+if [[ $@ == *"start-observer"* ]]; then
+    PROGRAM=/elrond/node
+    ARGS="${@//start-observer/}"
+elif [[ $@ == *"start-rosetta"* ]]; then
+    PROGRAM=/elrond/rosetta
+    ARGS="${@//start-rosetta/}"
+else
+    echo "Error: unknown program." 1>&2
+    exit 1
+fi
+
+echo "Program: ${PROGRAM}"
 
 # Create observer key (if missing)
 
@@ -46,5 +64,5 @@ fi
 
 # Run the main process (Node)
 
-echo "Node command-line arguments: ${NODE_ARGS}"
-exec /elrond/node ${NODE_ARGS}
+echo "Node command-line arguments: ${ARGS}"
+exec ${PROGRAM} ${ARGS}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,6 +16,9 @@ if [[ $@ == *"start-observer"* ]]; then
     elif [[ $@ == *"network=devnet"* ]]; then
         NETWORK=devnet
         ARGS="${ARGS//network=devnet/}"
+    elif [[ $@ == *"network=testnet"* ]]; then
+        NETWORK=testnet
+        ARGS="${ARGS//network=testnet/}"
     else
         echo "Error: unknown network switch." 1>&2
         exit 1
@@ -38,6 +41,8 @@ if [[ $@ == *"start-observer"* ]]; then
         ln -sf /elrond/config-mainnet /elrond/config
     elif [ "$NETWORK" == "devnet" ]; then
         ln -sf /elrond/config-devnet /elrond/config
+    elif [ "$NETWORK" == "testnet" ]; then
+        ln -sf /elrond/config-testnet /elrond/config
     fi
 
     echo "Created symlink to config folder."

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,26 +4,49 @@ NETWORK=""
 PROGRAM=""
 ARGS=""
 
-# Decide network
-
-if [[ $@ == *"network=mainnet"* ]]; then
-    NETWORK=mainnet
-    ARGS="${@//network=mainnet/}"
-elif [[ $@ == *"network=devnet"* ]]; then
-    NETWORK=devnet
-    ARGS="${@//network=devnet/}"
-else
-    echo "Error: unknown network switch." 1>&2
-    exit 1
-fi
-
-echo "Network: ${NETWORK}"
-
 # Decide program to run
-
 if [[ $@ == *"start-observer"* ]]; then
     PROGRAM=/elrond/node
     ARGS="${@//start-observer/}"
+
+    # For Node, decide network
+    if [[ $@ == *"network=mainnet"* ]]; then
+        NETWORK=mainnet
+        ARGS="${@//network=mainnet/}"
+    elif [[ $@ == *"network=devnet"* ]]; then
+        NETWORK=devnet
+        ARGS="${@//network=devnet/}"
+    else
+        echo "Error: unknown network switch." 1>&2
+        exit 1
+    fi
+
+    echo "Network: ${NETWORK}"
+
+    # For Node, create observer key (if missing)
+    if [ ! -f "/data/observerKey.pem" ]
+    then
+        /elrond/keygenerator
+        mv ./validatorKey.pem /data/observerKey.pem
+        echo "Created observer key."
+    else
+        echo "Observer key already existing."
+    fi
+
+    # For Node, symlink config (mainnet vs. devnet)
+    if [ "$NETWORK" == "mainnet" ]; then
+        ln -sf /elrond/config-mainnet /elrond/config
+    elif [ "$NETWORK" == "devnet" ]; then
+        ln -sf /elrond/config-devnet /elrond/config
+    fi
+
+    echo "Created symlink to config folder."
+
+    # For Node, check existence of /data/db
+    if [ ! -d "/data/db" ]; then
+        echo "Make sure the directory /data/db exists and contains a (recent) blockchain archive." 1>&2
+        exit 1
+    fi
 elif [[ $@ == *"start-rosetta"* ]]; then
     PROGRAM=/elrond/rosetta
     ARGS="${@//start-rosetta/}"
@@ -32,37 +55,7 @@ else
     exit 1
 fi
 
+# Run the main process:
 echo "Program: ${PROGRAM}"
-
-# Create observer key (if missing)
-
-if [ ! -f "/data/observerKey.pem" ]
-then
-    /elrond/keygenerator
-    mv ./validatorKey.pem /data/observerKey.pem
-    echo "Created observer key."
-else
-    echo "Observer key already existing."
-fi
-
-# Symlink config (mainnet vs. devnet)
-
-if [ "$NETWORK" == "mainnet" ]; then
-    ln -sf /elrond/config-mainnet /elrond/config
-elif [ "$NETWORK" == "devnet" ]; then
-    ln -sf /elrond/config-devnet /elrond/config
-fi
-
-echo "Created symlink to config folder."
-
-# Check existence of /data/db
-
-if [ ! -d "/data/db" ]; then
-    echo "Make sure the directory /data/db exists and contains a (recent) blockchain archive." 1>&2
-    exit 1
-fi
-
-# Run the main process (Node)
-
-echo "Node command-line arguments: ${ARGS}"
+echo "Command-line arguments: ${ARGS}"
 exec ${PROGRAM} ${ARGS}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,20 +2,20 @@
 
 NETWORK=""
 PROGRAM=""
-ARGS=""
+ARGS=$@
 
 # Decide program to run
 if [[ $@ == *"start-observer"* ]]; then
     PROGRAM=/elrond/node
-    ARGS="${@//start-observer/}"
+    ARGS="${ARGS//start-observer/}"
 
     # For Node, decide network
     if [[ $@ == *"network=mainnet"* ]]; then
         NETWORK=mainnet
-        ARGS="${@//network=mainnet/}"
+        ARGS="${ARGS//network=mainnet/}"
     elif [[ $@ == *"network=devnet"* ]]; then
         NETWORK=devnet
-        ARGS="${@//network=devnet/}"
+        ARGS="${ARGS//network=devnet/}"
     else
         echo "Error: unknown network switch." 1>&2
         exit 1
@@ -49,7 +49,7 @@ if [[ $@ == *"start-observer"* ]]; then
     fi
 elif [[ $@ == *"start-rosetta"* ]]; then
     PROGRAM=/elrond/rosetta
-    ARGS="${@//start-rosetta/}"
+    ARGS="${ARGS//start-rosetta/}"
 else
     echo "Error: unknown program." 1>&2
     exit 1

--- a/entrypoint_observer.sh
+++ b/entrypoint_observer.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+# Decide network
+
+NETWORK=$1
+if [[ $@ == *"network=mainnet"* ]]; then
+    NETWORK=mainnet
+    NODE_ARGS="${@//network=mainnet/}"
+elif [[ $@ == *"network=devnet"* ]]; then
+    NETWORK=devnet
+    NODE_ARGS="${@//network=devnet/}"
+else
+    echo "Error: unknown network switch." 1>&2
+    exit 1
+fi
+
+echo "Network: ${NETWORK}"
+
+# Create observer key (if missing)
+
+if [ ! -f "/data/observerKey.pem" ]
+then
+    /elrond/keygenerator
+    mv ./validatorKey.pem /data/observerKey.pem
+    echo "Created observer key."
+else
+    echo "Observer key already existing."
+fi
+
+# Symlink config (mainnet vs. devnet)
+
+if [ "$NETWORK" == "mainnet" ]; then
+    ln -sf /elrond/config-mainnet /elrond/config
+elif [ "$NETWORK" == "devnet" ]; then
+    ln -sf /elrond/config-devnet /elrond/config
+fi
+
+echo "Created symlink to config folder."
+
+# Check existence of /data/db
+
+if [ ! -d "/data/db" ]; then
+    echo "Make sure the directory /data/db exists and contains a (recent) blockchain archive." 1>&2
+    exit 1
+fi
+
+# Run the main process (Node)
+
+echo "Node command-line arguments: ${NODE_ARGS}"
+exec /elrond/node ${NODE_ARGS}


### PR DESCRIPTION
Initial PR. 

Scripts:
 - `adjust_config.py` (previously existing script)
 - `entrypoint.sh` (new script) - allows us to define a single Dockerfile (though, instantiated in 3 containers) for the whole Rosetta setup.
