### PR TITLE
Support for historical balances lookup

### DIFF
--- a/adjust_config.py
+++ b/adjust_config.py
@@ -32,10 +32,10 @@ def main(cli_args: List[str]):
     if mode == MODE_MAIN:
         data["GeneralSettings"]["StartInEpochEnabled"] = False
         data["DbLookupExtensions"]["Enabled"] = True
-        data["Antiflood"]["WebServer"]["SimultaneousRequests"] = api_simultaneous_requests
         data["StateTriesConfig"]["AccountsStatePruningEnabled"] = False
         data["StoragePruning"]["AccountsTrieCleanOldEpochsData"] = False
         data["StoragePruning"]["NumEpochsToKeep"] = num_epochs_to_keep
+        data["Antiflood"]["WebServer"]["SimultaneousRequests"] = api_simultaneous_requests
     elif mode == MODE_PREFS:
         data["Preferences"]["FullArchive"] = True
     else:

--- a/adjust_config.py
+++ b/adjust_config.py
@@ -29,6 +29,7 @@ def main(cli_args: List[str]):
         data["GeneralSettings"]["StartInEpochEnabled"] = False
         data["DbLookupExtensions"]["Enabled"] = True
         data["Antiflood"]["WebServer"]["SimultaneousRequests"] = 512
+        data["StateTriesConfig"]["AccountsStatePruningEnabled"] = False
     elif mode == MODE_PREFS:
         data["Preferences"]["FullArchive"] = True
     else:

--- a/adjust_config.py
+++ b/adjust_config.py
@@ -30,6 +30,8 @@ def main(cli_args: List[str]):
         data["DbLookupExtensions"]["Enabled"] = True
         data["Antiflood"]["WebServer"]["SimultaneousRequests"] = 512
         data["StateTriesConfig"]["AccountsStatePruningEnabled"] = False
+        data["StoragePruning"]["AccountsTrieCleanOldEpochsData"] = False
+        data["StoragePruning"]["NumEpochsToKeep"] = 128
     elif mode == MODE_PREFS:
         data["Preferences"]["FullArchive"] = True
     else:

--- a/adjust_config.py
+++ b/adjust_config.py
@@ -18,20 +18,24 @@ def main(cli_args: List[str]):
     parser = ArgumentParser()
     parser.add_argument("--mode", choices=MODES, required=True)
     parser.add_argument("--file", required=True)
+    parser.add_argument("--api-simultaneous-requests", type=int, default=512)
+    parser.add_argument("--num-epochs-to-keep", type=int, default=128)
 
     parsed_args = parser.parse_args(cli_args)
     mode = parsed_args.mode
     file = parsed_args.file
+    api_simultaneous_requests = parsed_args.api_simultaneous_requests
+    num_epochs_to_keep = parsed_args.num_epochs_to_keep
 
     data = toml.load(file)
 
     if mode == MODE_MAIN:
         data["GeneralSettings"]["StartInEpochEnabled"] = False
         data["DbLookupExtensions"]["Enabled"] = True
-        data["Antiflood"]["WebServer"]["SimultaneousRequests"] = 512
+        data["Antiflood"]["WebServer"]["SimultaneousRequests"] = api_simultaneous_requests
         data["StateTriesConfig"]["AccountsStatePruningEnabled"] = False
         data["StoragePruning"]["AccountsTrieCleanOldEpochsData"] = False
-        data["StoragePruning"]["NumEpochsToKeep"] = 128
+        data["StoragePruning"]["NumEpochsToKeep"] = num_epochs_to_keep
     elif mode == MODE_PREFS:
         data["Preferences"]["FullArchive"] = True
     else:


### PR DESCRIPTION
 - Set `StateTriesConfig.AccountsStatePruningEnabled = False`.
 - Set `StoragePruning.AccountsTrieCleanOldEpochsData = False`.
 - Set `StoragePruning.NumEpochsToKeep` wrt. a CLI argument.
 - Set `Antiflood.WebServer.SimultaneousRequests` wrt. a CLI argument.