### PR TITLE
Adjust for separate binaries (devnet, mainnet).

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,7 +6,6 @@ ARGS=$@
 
 # Decide program to run
 if [[ $@ == *"start-observer"* ]]; then
-    PROGRAM=/elrond/node
     ARGS="${ARGS//start-observer/}"
 
     # For Node, decide network
@@ -36,16 +35,17 @@ if [[ $@ == *"start-observer"* ]]; then
         echo "Observer key already existing."
     fi
 
-    # For Node, symlink config (mainnet vs. devnet)
+    # For Node, decide executable and export LD_LIBRARY_PATH (mainnet vs. devnet vs. testnet)
     if [ "$NETWORK" == "mainnet" ]; then
-        ln -sf /elrond/config-mainnet /elrond/config
+        PROGRAM=/elrond/mainnet/node
+        export LD_LIBRARY_PATH=/elrond/mainnet
     elif [ "$NETWORK" == "devnet" ]; then
-        ln -sf /elrond/config-devnet /elrond/config
+        PROGRAM=/elrond/devnet/node
+        export LD_LIBRARY_PATH=/elrond/devnet
     elif [ "$NETWORK" == "testnet" ]; then
-        ln -sf /elrond/config-testnet /elrond/config
+        PROGRAM=/elrond/testnet/node
+        export LD_LIBRARY_PATH=/elrond/testnet
     fi
-
-    echo "Created symlink to config folder."
 
     # For Node, check existence of /data/db
     if [ ! -d "/data/db" ]; then
@@ -63,4 +63,5 @@ fi
 # Run the main process:
 echo "Program: ${PROGRAM}"
 echo "Command-line arguments: ${ARGS}"
+echo "LD_LIBRARY_PATH: ${LD_LIBRARY_PATH}"
 exec ${PROGRAM} ${ARGS}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -35,17 +35,10 @@ if [[ $@ == *"start-observer"* ]]; then
         echo "Observer key already existing."
     fi
 
-    # For Node, decide executable and export LD_LIBRARY_PATH (mainnet vs. devnet vs. testnet)
-    if [ "$NETWORK" == "mainnet" ]; then
-        PROGRAM=/elrond/mainnet/node
-        export LD_LIBRARY_PATH=/elrond/mainnet
-    elif [ "$NETWORK" == "devnet" ]; then
-        PROGRAM=/elrond/devnet/node
-        export LD_LIBRARY_PATH=/elrond/devnet
-    elif [ "$NETWORK" == "testnet" ]; then
-        PROGRAM=/elrond/testnet/node
-        export LD_LIBRARY_PATH=/elrond/testnet
-    fi
+    # For Node, decide current directory, executable and export LD_LIBRARY_PATH (mainnet vs. devnet vs. testnet)
+    DIRECTORY=/elrond/${NETWORK}
+    PROGRAM=${DIRECTORY}/node
+    export LD_LIBRARY_PATH=${DIRECTORY}
 
     # For Node, check existence of /data/db
     if [ ! -d "/data/db" ]; then
@@ -53,7 +46,8 @@ if [[ $@ == *"start-observer"* ]]; then
         exit 1
     fi
 elif [[ $@ == *"start-rosetta"* ]]; then
-    PROGRAM=/elrond/rosetta
+    DIRECTORY=/elrond
+    PROGRAM=${DIRECTORY}/rosetta
     ARGS="${ARGS//start-rosetta/}"
 else
     echo "Error: unknown program." 1>&2
@@ -61,6 +55,7 @@ else
 fi
 
 # Run the main process:
+cd ${DIRECTORY}
 echo "Program: ${PROGRAM}"
 echo "Command-line arguments: ${ARGS}"
 echo "LD_LIBRARY_PATH: ${LD_LIBRARY_PATH}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,30 +1,13 @@
 #!/bin/bash
 
-NETWORK=""
-PROGRAM=""
 ARGS=$@
 
+echo "Network: ${NETWORK}"
+echo "Program: ${PROGRAM}"
+echo "Args: ${ARGS}"
+
 # Decide program to run
-if [[ $@ == *"start-observer"* ]]; then
-    ARGS="${ARGS//start-observer/}"
-
-    # For Node, decide network
-    if [[ $@ == *"network=mainnet"* ]]; then
-        NETWORK=mainnet
-        ARGS="${ARGS//network=mainnet/}"
-    elif [[ $@ == *"network=devnet"* ]]; then
-        NETWORK=devnet
-        ARGS="${ARGS//network=devnet/}"
-    elif [[ $@ == *"network=testnet"* ]]; then
-        NETWORK=testnet
-        ARGS="${ARGS//network=testnet/}"
-    else
-        echo "Error: unknown network switch." 1>&2
-        exit 1
-    fi
-
-    echo "Network: ${NETWORK}"
-
+if [[ ${PROGRAM} == "node" ]]; then
     # For Node, create observer key (if missing)
     if [ ! -f "/data/observerKey.pem" ]
     then
@@ -35,28 +18,19 @@ if [[ $@ == *"start-observer"* ]]; then
         echo "Observer key already existing."
     fi
 
-    # For Node, decide current directory, executable and export LD_LIBRARY_PATH (mainnet vs. devnet vs. testnet)
-    DIRECTORY=/elrond/${NETWORK}
-    PROGRAM=${DIRECTORY}/node
-    export LD_LIBRARY_PATH=${DIRECTORY}
-
     # For Node, check existence of /data/db
     if [ ! -d "/data/db" ]; then
         echo "Make sure the directory /data/db exists and contains a (recent) blockchain archive." 1>&2
         exit 1
     fi
-elif [[ $@ == *"start-rosetta"* ]]; then
-    DIRECTORY=/elrond
-    PROGRAM=${DIRECTORY}/rosetta
-    ARGS="${ARGS//start-rosetta/}"
-else
-    echo "Error: unknown program." 1>&2
-    exit 1
 fi
+
+DIRECTORY=/elrond/${NETWORK}
+export LD_LIBRARY_PATH=${DIRECTORY}
 
 # Run the main process:
 cd ${DIRECTORY}
 echo "Program: ${PROGRAM}"
 echo "Command-line arguments: ${ARGS}"
 echo "LD_LIBRARY_PATH: ${LD_LIBRARY_PATH}"
-exec ${PROGRAM} ${ARGS}
+exec ./${PROGRAM} ${ARGS}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,9 +6,9 @@ echo "Network: ${NETWORK}"
 echo "Program: ${PROGRAM}"
 echo "Args: ${ARGS}"
 
-# Decide program to run
+# For Node (observer), perform additional steps
 if [[ ${PROGRAM} == "node" ]]; then
-    # For Node, create observer key (if missing)
+    # Create observer key (if missing)
     if [ ! -f "/data/observerKey.pem" ]
     then
         /elrond/keygenerator
@@ -18,7 +18,7 @@ if [[ ${PROGRAM} == "node" ]]; then
         echo "Observer key already existing."
     fi
 
-    # For Node, check existence of /data/db
+    # Check existence of /data/db
     if [ ! -d "/data/db" ]; then
         echo "Make sure the directory /data/db exists and contains a (recent) blockchain archive." 1>&2
         exit 1


### PR DESCRIPTION
 - Adjust `entrypoint` to accommodate separate node binaries: devnet, mainnet.
 - Receive and handle the environment variables `PROGRAM` (_node_ or _rosetta_) and `NETWORK` (_mainnet_ or _devnet_).
 - Simplify conditions / if statements
 - export `LD_LIBRARY_PATH` (instead of copying libwasmer into `/lib`)

Related to: https://github.com/ElrondNetwork/rosetta-docker/pull/24