### PR TITLE
Update for mx-chain-go v1.4

### DIFF
--- a/adjust_config.py
+++ b/adjust_config.py
@@ -33,7 +33,7 @@ def main(cli_args: List[str]):
         data["StateTriesConfig"]["AccountsStatePruningEnabled"] = False
         data["StoragePruning"]["ObserverCleanOldEpochsData"] = False
         data["StoragePruning"]["AccountsTrieCleanOldEpochsData"] = False
-        data["Antiflood"]["WebServer"]["SimultaneousRequests"] = api_simultaneous_requests
+        data["WebServerAntiflood"]["SimultaneousRequests"] = api_simultaneous_requests
     elif mode == MODE_PREFS:
         data["Preferences"]["FullArchive"] = True
     else:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -119,16 +119,6 @@ downloadNonPrunedEpochs() {
 
 # For Node (observer), perform additional steps
 if [[ ${PROGRAM} == "node" ]]; then
-    # Create observer key (if missing)
-    if [ ! -f "/data/observerKey.pem" ]
-    then
-        /app/keygenerator || exit 1
-        mv ./validatorKey.pem /data/observerKey.pem || exit 1
-        echo "Created observer key."
-    else
-        echo "Observer key already existing."
-    fi
-
     downloadDataIfNecessary || exit 1
 
     # Check existence of /data/db


### PR DESCRIPTION
 - Do not generate `observerKey.pem` anymore. The `--no-key` parameter will be used on the in docker compose configuration.
 - Adjust configuration for max API `SimultaneousRequests`.

Related PR: https://github.com/multiversx/mx-chain-rosetta-docker/pull/27.