### PR TITLE
Allow one to configure "SyncProcessTimeInMillis" and "MaxHeaderRequestsAllowed"

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+ignore = E501

--- a/adjust_config.py
+++ b/adjust_config.py
@@ -20,6 +20,7 @@ def main(cli_args: List[str]):
     parser.add_argument("--file", required=True)
     parser.add_argument("--api-simultaneous-requests", type=int, default=16384)
     parser.add_argument("--no-snapshots", action="store_true", default=False)
+    parser.add_argument("--sync-process-time-milliseconds", type=int, default=12000)
 
     parsed_args = parser.parse_args(cli_args)
     mode = parsed_args.mode
@@ -27,11 +28,13 @@ def main(cli_args: List[str]):
     api_simultaneous_requests = parsed_args.api_simultaneous_requests
     no_snapshots = parsed_args.no_snapshots
     snapshots_enabled = not no_snapshots
+    sync_process_time_milliseconds = parsed_args.sync_process_time_milliseconds
 
     data = toml.load(file)
 
     if mode == MODE_MAIN:
         data["GeneralSettings"]["StartInEpochEnabled"] = False
+        data["GeneralSettings"]["SyncProcessTimeInMillis"] = sync_process_time_milliseconds
         data["DbLookupExtensions"]["Enabled"] = True
         data["StateTriesConfig"]["AccountsStatePruningEnabled"] = False
         data["StateTriesConfig"]["SnapshotsEnabled"] = snapshots_enabled

--- a/adjust_observer_src.py
+++ b/adjust_observer_src.py
@@ -11,13 +11,13 @@ python3 adjust_observer_src.py --src=...
 def main(cli_args: List[str]):
     parser = ArgumentParser()
     parser.add_argument("--src", type=Path, required=True)
-    parser.add_argument("--max-header-requests-allowed", type=int, default=20)
+    parser.add_argument("--max-headers-to-request-in-advance", type=int, default=20)
 
     parsed_args = parser.parse_args(cli_args)
     src = parsed_args.src
-    max_header_requests_allowed = parsed_args.max_header_requests_allowed
+    max_headers_to_request_in_advance = parsed_args.max_headers_to_request_in_advance
 
-    replace_line_in_file(src / "process" / "constants.go", "const MaxHeaderRequestsAllowed = 20", f"const MaxHeaderRequestsAllowed = {max_header_requests_allowed}")
+    replace_line_in_file(src / "process" / "constants.go", "const MaxHeadersToRequestInAdvance = 20", f"const MaxHeadersToRequestInAdvance = {max_headers_to_request_in_advance}")
 
 
 def replace_line_in_file(file: Path, old: str, new: str):

--- a/adjust_observer_src.py
+++ b/adjust_observer_src.py
@@ -17,7 +17,7 @@ def main(cli_args: List[str]):
     src = parsed_args.src
     max_header_requests_allowed = parsed_args.max_header_requests_allowed
 
-    replace_line_in_file(src / "process" / "constants.go", "MaxHeaderRequestsAllowed = 20", f"MaxHeaderRequestsAllowed = {max_header_requests_allowed}")
+    replace_line_in_file(src / "process" / "constants.go", "const MaxHeaderRequestsAllowed = 20", f"const MaxHeaderRequestsAllowed = {max_header_requests_allowed}")
 
 
 def replace_line_in_file(file: Path, old: str, new: str):

--- a/adjust_observer_src.py
+++ b/adjust_observer_src.py
@@ -1,0 +1,40 @@
+import sys
+from argparse import ArgumentParser
+from pathlib import Path
+from typing import List
+
+"""
+python3 adjust_observer_src.py --src=...
+"""
+
+
+def main(cli_args: List[str]):
+    parser = ArgumentParser()
+    parser.add_argument("--src", type=Path, required=True)
+    parser.add_argument("--max-header-requests-allowed", type=int, default=20)
+
+    parsed_args = parser.parse_args(cli_args)
+    src = parsed_args.src
+    max_header_requests_allowed = parsed_args.max_header_requests_allowed
+
+    replace_line_in_file(src / "process" / "constants.go", "MaxHeaderRequestsAllowed = 20", f"MaxHeaderRequestsAllowed = {max_header_requests_allowed}")
+
+
+def replace_line_in_file(file: Path, old: str, new: str):
+    lines_input = file.read_text().splitlines()
+    lines_output: List[str] = []
+
+    if old not in lines_input:
+        raise Exception(f"Line not found in {file}: {old}")
+
+    for line in lines_input:
+        if line == old:
+            lines_output.append(new)
+        else:
+            lines_output.append(line)
+
+    file.write_text("\n".join(lines_output) + "\n")
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])


### PR DESCRIPTION
Allow one to set configuration entry `GeneralSettings.SyncProcessTimeInMillis`: https://github.com/multiversx/mx-chain-go/blob/master/cmd/node/config/config.toml#L36. Setting this to a lower value (but not too low, though) should speed-up blocks sync from past epochs.

Furthermore, allow one to adjust the constant `MaxHeadersToRequestInAdvance`: https://github.com/multiversx/mx-chain-go/blob/master/process/constants.go

